### PR TITLE
Configure Prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ npm-debug.log*
 *.db-journal
 
 # editor
-.vscode/
 .idea/
 
 # Claude

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.db

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "printWidth": 100,
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSameLine": false,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSameLine": false,
+  "bracketSpacing": false,
+  "arrowParens": "always",
+  "jsxSingleQuote": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "client",
         "server",
         "shared"
-      ]
+      ],
+      "devDependencies": {
+        "prettier": "^3.8.3"
+      }
     },
     "client": {
       "version": "1.0.0",
@@ -529,6 +532,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/server": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "workspaces": [
     "client",
     "server",
     "shared"
   ],
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "prettier": "^3.8.3"
+  }
 }

--- a/server/scripts/explore-sleeper.ts
+++ b/server/scripts/explore-sleeper.ts
@@ -1,23 +1,23 @@
 const fetcher = async (url: string | URL): Promise<unknown> => {
-  const response = await fetch(url);
-  if(!response.ok) {
-    throw new Error(`HTTP ${response.status} for ${url}`);
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`)
   }
-  const data = await response.json();
-  return data;
+  const data = await response.json()
+  return data
 }
 
 const user_id = process.env.SLEEPER_USER_ID
-if(!user_id) {
+if (!user_id) {
   throw new Error('Sleeper USER_ID not set in .env')
 }
 
 const league_id = process.env.SLEEPER_DYNASTY_LEAGUE_ID
-if(!league_id) {
+if (!league_id) {
   throw new Error('Sleeper dynasty league id not set in env')
 }
 
-const userRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}`);
+const userRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}`)
 
 const leaguesRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}/leagues/nfl/2026`)
 
@@ -27,5 +27,4 @@ const rostersRes = await fetcher(`https://api.sleeper.app/v1/league/${league_id}
 
 console.log(rostersRes)
 
-export { };
-
+export {}

--- a/server/scripts/explore-sleeper.ts
+++ b/server/scripts/explore-sleeper.ts
@@ -1,30 +1,30 @@
 const fetcher = async (url: string | URL): Promise<unknown> => {
-  const response = await fetch(url)
+  const response = await fetch(url);
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status} for ${url}`)
+    throw new Error(`HTTP ${response.status} for ${url}`);
   }
-  const data = await response.json()
-  return data
-}
+  const data = await response.json();
+  return data;
+};
 
-const user_id = process.env.SLEEPER_USER_ID
+const user_id = process.env.SLEEPER_USER_ID;
 if (!user_id) {
-  throw new Error('Sleeper USER_ID not set in .env')
+  throw new Error('Sleeper USER_ID not set in .env');
 }
 
-const league_id = process.env.SLEEPER_DYNASTY_LEAGUE_ID
+const league_id = process.env.SLEEPER_DYNASTY_LEAGUE_ID;
 if (!league_id) {
-  throw new Error('Sleeper dynasty league id not set in env')
+  throw new Error('Sleeper dynasty league id not set in env');
 }
 
-const userRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}`)
+const userRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}`);
 
-const leaguesRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}/leagues/nfl/2026`)
+const leaguesRes = await fetcher(`https://api.sleeper.app/v1/user/${user_id}/leagues/nfl/2026`);
 
-const dynastyRes = await fetcher(`https://api.sleeper.app/v1/league/${league_id}`)
+const dynastyRes = await fetcher(`https://api.sleeper.app/v1/league/${league_id}`);
 
-const rostersRes = await fetcher(`https://api.sleeper.app/v1/league/${league_id}/rosters`)
+const rostersRes = await fetcher(`https://api.sleeper.app/v1/league/${league_id}/rosters`);
 
-console.log(rostersRes)
+console.log(rostersRes);
 
-export {}
+export {};

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,1 @@
-export * from './types/sleeper'
+export * from './types/sleeper';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./types/sleeper"
+export * from './types/sleeper'

--- a/shared/src/types/sleeper.ts
+++ b/shared/src/types/sleeper.ts
@@ -1,124 +1,124 @@
 // ── Primitives ────────────────────────────────────────────────────────────────
 
-export type EpochTimeStamp = number
+export type EpochTimeStamp = number;
 
 // ── Shared enums ──────────────────────────────────────────────────────────────
 
-export type SleeperScoringType = 'ppr' | 'half_ppr' | 'standard'
+export type SleeperScoringType = 'ppr' | 'half_ppr' | 'standard';
 
-export type SleeperSeasonType = 'regular' | 'pre' | 'post'
+export type SleeperSeasonType = 'regular' | 'pre' | 'post';
 
 // ── User ──────────────────────────────────────────────────────────────────────
 
 export type SleeperUser = {
-  username: string
-  user_id: string
-  display_name: string | null
-  avatar: string | null
-  real_name: string | null
-  is_bot: boolean
-  metadata: Record<string, string> | null
-  [key: string]: unknown
-}
+  username: string;
+  user_id: string;
+  display_name: string | null;
+  avatar: string | null;
+  real_name: string | null;
+  is_bot: boolean;
+  metadata: Record<string, string> | null;
+  [key: string]: unknown;
+};
 
 export type SleeperLeagueUser = SleeperUser & {
-  team_name: string
-  is_owner: boolean
-}
+  team_name: string;
+  is_owner: boolean;
+};
 
 // ── League ────────────────────────────────────────────────────────────────────
 
-export type SleeperLeagueStatus = 'pre_draft' | 'drafting' | 'in_season' | 'complete'
+export type SleeperLeagueStatus = 'pre_draft' | 'drafting' | 'in_season' | 'complete';
 
 export type SleeperLeague = {
-  league_id: string
-  name: string
-  status: SleeperLeagueStatus
-  sport: 'nfl'
-  season: string
-  season_type: SleeperSeasonType
-  total_rosters: number
-  draft_id: string
-  previous_league_id: string | null
-  avatar: string | null
-  settings: Record<string, unknown>
-  scoring_settings: Record<string, number>
-  roster_positions: string[]
-  metadata: Record<string, string> | null
-  [key: string]: unknown
-}
+  league_id: string;
+  name: string;
+  status: SleeperLeagueStatus;
+  sport: 'nfl';
+  season: string;
+  season_type: SleeperSeasonType;
+  total_rosters: number;
+  draft_id: string;
+  previous_league_id: string | null;
+  avatar: string | null;
+  settings: Record<string, unknown>;
+  scoring_settings: Record<string, number>;
+  roster_positions: string[];
+  metadata: Record<string, string> | null;
+  [key: string]: unknown;
+};
 
 // ── Draft ─────────────────────────────────────────────────────────────────────
 
-export type SleeperDraftType = 'snake' | 'auction' | 'linear'
+export type SleeperDraftType = 'snake' | 'auction' | 'linear';
 
-export type SleeperDraftStatus = 'pre_draft' | 'drafting' | 'complete' | 'paused'
+export type SleeperDraftStatus = 'pre_draft' | 'drafting' | 'complete' | 'paused';
 
 export type SleeperDraftSettings = {
-  teams: number
-  rounds: number
-  pick_timer: number
-  slots_qb: number
-  slots_rb: number
-  slots_wr: number
-  slots_te: number
-  slots_k: number
-  slots_flex: number
-  slots_def: number
-  slots_bn: number
-}
+  teams: number;
+  rounds: number;
+  pick_timer: number;
+  slots_qb: number;
+  slots_rb: number;
+  slots_wr: number;
+  slots_te: number;
+  slots_k: number;
+  slots_flex: number;
+  slots_def: number;
+  slots_bn: number;
+};
 
 export type SleeperDraftMetadata = {
-  scoring_type: SleeperScoringType
-  name: string
-  description: string
-}
+  scoring_type: SleeperScoringType;
+  name: string;
+  description: string;
+};
 
 export type SleeperDraft = {
-  draft_id: string
-  league_id: string
-  type: SleeperDraftType
-  status: SleeperDraftStatus
-  sport: 'nfl'
-  season: string
-  season_type: SleeperSeasonType
-  settings: SleeperDraftSettings
-  metadata: SleeperDraftMetadata
-  start_time: EpochTimeStamp
-  last_picked: EpochTimeStamp
-  last_message_time: EpochTimeStamp
-  last_message_id: string
-  created: EpochTimeStamp
-  draft_order: Record<string, number> | null
-  creators: string[] | null
-  [key: string]: unknown
-}
+  draft_id: string;
+  league_id: string;
+  type: SleeperDraftType;
+  status: SleeperDraftStatus;
+  sport: 'nfl';
+  season: string;
+  season_type: SleeperSeasonType;
+  settings: SleeperDraftSettings;
+  metadata: SleeperDraftMetadata;
+  start_time: EpochTimeStamp;
+  last_picked: EpochTimeStamp;
+  last_message_time: EpochTimeStamp;
+  last_message_id: string;
+  created: EpochTimeStamp;
+  draft_order: Record<string, number> | null;
+  creators: string[] | null;
+  [key: string]: unknown;
+};
 
 // ── Roster & Picks ────────────────────────────────────────────────────────────
 
 export type SleeperRoster = {
-  roster_id: number
-  owner_id: string
-  league_id: string
-  players: string[] | null
-  starters: string[]
-  reserve: string[] | null
-  taxi: string[] | null
-  co_owners: string[] | null
-  settings: Record<string, number>
-  metadata: Record<string, string> | null
-}
+  roster_id: number;
+  owner_id: string;
+  league_id: string;
+  players: string[] | null;
+  starters: string[];
+  reserve: string[] | null;
+  taxi: string[] | null;
+  co_owners: string[] | null;
+  settings: Record<string, number>;
+  metadata: Record<string, string> | null;
+};
 
 export type SleeperDraftPick = {
-  season: string
-  round: number
-  roster_id: number
-}
+  season: string;
+  round: number;
+  roster_id: number;
+};
 
 export type SleeperTradedDraftPick = SleeperDraftPick & {
-  owner_id: number
-  previous_owner_id: number
-}
+  owner_id: number;
+  previous_owner_id: number;
+};
 
 // ── Player ────────────────────────────────────────────────────────────────────
 
@@ -130,60 +130,60 @@ export type SleeperPlayerStatus =
   | 'Practice Squad'
   | 'Injured Reserve'
   | 'Non-Football Injury'
-  | 'Commissioner Designated'
+  | 'Commissioner Designated';
 
-export type SleeperInjuryStatus = 'Questionable' | 'Doubtful' | 'Out' | 'IR' | 'PUP' | 'DNR'
+export type SleeperInjuryStatus = 'Questionable' | 'Doubtful' | 'Out' | 'IR' | 'PUP' | 'DNR';
 
 export type SleeperPracticeParticipation =
   | 'Full Participant'
   | 'Limited Participant'
-  | 'Did Not Participate'
+  | 'Did Not Participate';
 
-export type SleeperPlayerKey = string
+export type SleeperPlayerKey = string;
 
 export type SleeperPlayerDetails = {
   // identity
-  first_name: string
-  last_name: string
-  full_name: string | null
-  player_id: string
+  first_name: string;
+  last_name: string;
+  full_name: string | null;
+  player_id: string;
 
   // bio — critical for dynasty value
-  age: number | null
-  birth_date: string | null
-  height: string | null
-  weight: string | null
-  college: string | null
-  years_exp: number | null
+  age: number | null;
+  birth_date: string | null;
+  height: string | null;
+  weight: string | null;
+  college: string | null;
+  years_exp: number | null;
 
   // position / depth
-  position: string
-  fantasy_positions: string[]
-  depth_chart_position: string | null
-  depth_chart_order: number | null
-  number: number | null
-  sport: 'nfl'
+  position: string;
+  fantasy_positions: string[];
+  depth_chart_position: string | null;
+  depth_chart_order: number | null;
+  number: number | null;
+  sport: 'nfl';
 
   // team
-  team: string | null
+  team: string | null;
 
   // status
-  status: SleeperPlayerStatus | null
-  active: boolean
-  injury_status: SleeperInjuryStatus | null
-  injury_start_date: string | null
-  injury_body_part: string | null
-  injury_notes: string | null
-  practice_participation: SleeperPracticeParticipation | null
+  status: SleeperPlayerStatus | null;
+  active: boolean;
+  injury_status: SleeperInjuryStatus | null;
+  injury_start_date: string | null;
+  injury_body_part: string | null;
+  injury_notes: string | null;
+  practice_participation: SleeperPracticeParticipation | null;
 
   // search / external
-  hashtag: string | null
-  search_last_name: string | null
-  search_first_name: string | null
-  search_rank: number | null
-  fantasy_data_id: number | null
+  hashtag: string | null;
+  search_last_name: string | null;
+  search_first_name: string | null;
+  search_rank: number | null;
+  fantasy_data_id: number | null;
 
-  [key: string]: unknown
-}
+  [key: string]: unknown;
+};
 
-export type SleeperPlayersMap = Record<SleeperPlayerKey, SleeperPlayerDetails>
+export type SleeperPlayersMap = Record<SleeperPlayerKey, SleeperPlayerDetails>;

--- a/shared/src/types/sleeper.ts
+++ b/shared/src/types/sleeper.ts
@@ -4,9 +4,9 @@ export type EpochTimeStamp = number
 
 // ── Shared enums ──────────────────────────────────────────────────────────────
 
-export type SleeperScoringType = "ppr" | "half_ppr" | "standard"
+export type SleeperScoringType = 'ppr' | 'half_ppr' | 'standard'
 
-export type SleeperSeasonType = "regular" | "pre" | "post"
+export type SleeperSeasonType = 'regular' | 'pre' | 'post'
 
 // ── User ──────────────────────────────────────────────────────────────────────
 
@@ -28,17 +28,13 @@ export type SleeperLeagueUser = SleeperUser & {
 
 // ── League ────────────────────────────────────────────────────────────────────
 
-export type SleeperLeagueStatus =
-  | "pre_draft"
-  | "drafting"
-  | "in_season"
-  | "complete"
+export type SleeperLeagueStatus = 'pre_draft' | 'drafting' | 'in_season' | 'complete'
 
 export type SleeperLeague = {
   league_id: string
   name: string
   status: SleeperLeagueStatus
-  sport: "nfl"
+  sport: 'nfl'
   season: string
   season_type: SleeperSeasonType
   total_rosters: number
@@ -54,9 +50,9 @@ export type SleeperLeague = {
 
 // ── Draft ─────────────────────────────────────────────────────────────────────
 
-export type SleeperDraftType = "snake" | "auction" | "linear"
+export type SleeperDraftType = 'snake' | 'auction' | 'linear'
 
-export type SleeperDraftStatus = "pre_draft" | "drafting" | "complete" | "paused"
+export type SleeperDraftStatus = 'pre_draft' | 'drafting' | 'complete' | 'paused'
 
 export type SleeperDraftSettings = {
   teams: number
@@ -83,7 +79,7 @@ export type SleeperDraft = {
   league_id: string
   type: SleeperDraftType
   status: SleeperDraftStatus
-  sport: "nfl"
+  sport: 'nfl'
   season: string
   season_type: SleeperSeasonType
   settings: SleeperDraftSettings
@@ -127,27 +123,21 @@ export type SleeperTradedDraftPick = SleeperDraftPick & {
 // ── Player ────────────────────────────────────────────────────────────────────
 
 export type SleeperPlayerStatus =
-  | "Active"
-  | "Inactive"
-  | "PUP"
-  | "Suspended"
-  | "Practice Squad"
-  | "Injured Reserve"
-  | "Non-Football Injury"
-  | "Commissioner Designated"
+  | 'Active'
+  | 'Inactive'
+  | 'PUP'
+  | 'Suspended'
+  | 'Practice Squad'
+  | 'Injured Reserve'
+  | 'Non-Football Injury'
+  | 'Commissioner Designated'
 
-export type SleeperInjuryStatus =
-  | "Questionable"
-  | "Doubtful"
-  | "Out"
-  | "IR"
-  | "PUP"
-  | "DNR"
+export type SleeperInjuryStatus = 'Questionable' | 'Doubtful' | 'Out' | 'IR' | 'PUP' | 'DNR'
 
 export type SleeperPracticeParticipation =
-  | "Full Participant"
-  | "Limited Participant"
-  | "Did Not Participate"
+  | 'Full Participant'
+  | 'Limited Participant'
+  | 'Did Not Participate'
 
 export type SleeperPlayerKey = string
 
@@ -172,7 +162,7 @@ export type SleeperPlayerDetails = {
   depth_chart_position: string | null
   depth_chart_order: number | null
   number: number | null
-  sport: "nfl"
+  sport: 'nfl'
 
   // team
   team: string | null


### PR DESCRIPTION
Adds Prettier for consistent code formatting across the monorepo with format-on-save wired up in VS Code.

## Changes

- **`.prettierrc`** — Prettier config at the repo root: 100 char print width, yes semicolons, single quotes, ES5 trailing commas
- **`.prettierignore`** — Excludes `node_modules`, `dist`, `build`, `*.db`, and `package-lock.json` from formatting
- **`package.json`** — Added `format` (`prettier --write .`) and `format:check` (`prettier --check .`) scripts to the root workspace; added `prettier` as a root dev dependency
- **`.vscode/settings.json`** — Sets Prettier as the default formatter with `formatOnSave: true`
- **`server/scripts/explore-sleeper.ts`**, **`shared/src/index.ts`**, **`shared/src/types/sleeper.ts`** — Reformatted by Prettier on first run