### PR TITLE
League details + enriched rosters API

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import {playersRouter} from './routes/players';
+import {leaguesRouter} from './routes/leagues';
 
 const app = express();
 const port = 3000;
@@ -9,6 +10,7 @@ app.get('/api/health', (req, res) => {
 });
 
 app.use('/api/players', playersRouter);
+app.use('/api/league', leaguesRouter);
 
 app.listen(port, () => {
   console.log(`The dynastic cycle app is listening on port ${port}`);

--- a/server/src/routes/leagues.ts
+++ b/server/src/routes/leagues.ts
@@ -1,0 +1,14 @@
+import {Router} from 'express';
+import {getEnrichedRosters, getLeagueDetails} from '../sleeper/league';
+
+export const leaguesRouter = Router();
+
+leaguesRouter.get('/', async (req, res) => {
+  const result = await getLeagueDetails();
+  res.json(result);
+});
+
+leaguesRouter.get('/rosters', async (req, res) => {
+  const result = await getEnrichedRosters();
+  res.json(result);
+});

--- a/server/src/sleeper/league.ts
+++ b/server/src/sleeper/league.ts
@@ -1,0 +1,41 @@
+import {SleeperLeague, SleeperRoster} from 'shared';
+import {fetcher, SLEEPER_BASE_API} from './client';
+import {prisma} from '../db';
+import type {PlayerCache} from '../generated/prisma/client';
+
+type EnrichedRoster = Omit<SleeperRoster, 'players'> & {
+  players: PlayerCache[];
+};
+
+export const getLeagueDetails = async (): Promise<SleeperLeague> => {
+  const leagueId = process.env.SLEEPER_DYNASTY_LEAGUE_ID;
+  if (!leagueId) {
+    throw new Error('SLEEPER_DYNASTY_LEAGUE_ID not set in .env');
+  }
+  return fetcher<SleeperLeague>(`${SLEEPER_BASE_API}/league/${leagueId}`);
+};
+
+// helper to fetch the rosters in the league and enrich them from the PlayerCache.
+export const getEnrichedRosters = async (): Promise<EnrichedRoster[]> => {
+  const leagueId = process.env.SLEEPER_DYNASTY_LEAGUE_ID;
+  if (!leagueId) {
+    throw new Error('SLEEPER_DYNASTY_LEAGUE_ID not set in .env');
+  }
+  const rawRosters = await fetcher<SleeperRoster[]>(
+    `${SLEEPER_BASE_API}/league/${leagueId}/rosters`
+  );
+
+  const ids = rawRosters.flatMap((r) => r.players ?? []);
+  const players = await prisma.playerCache.findMany({
+    where: {id: {in: ids}},
+  });
+
+  const playerById = Object.fromEntries(players.map((p) => [p.id, p]));
+
+  return rawRosters.map((r) => ({
+    ...r,
+    players: (r.players ?? [])
+      .map((id) => playerById[id])
+      .filter((p): p is PlayerCache => p != null),
+  }));
+};


### PR DESCRIPTION
## Summary

First time the cached player data actually gets used. Adds two read-only league endpoints that fetch live from Sleeper and (for rosters) enrich the player IDs against the local `PlayerCache` so the response carries real names, positions, and ages instead of opaque strings.

## Key changes

- **`server/src/sleeper/league.ts`**
  - `getLeagueDetails()` — fetches `/league/{id}` from Sleeper using `SLEEPER_DYNASTY_LEAGUE_ID` from env.
  - `getEnrichedRosters()` — fetches `/league/{id}/rosters`, flattens all player IDs across the league into a single array, batches one `prisma.playerCache.findMany({ where: { id: { in: ids } } })`, then maps each roster's IDs through a lookup so its `players` field becomes `PlayerCache[]` instead of `string[]`.
  - `EnrichedRoster` type uses `Omit<SleeperRoster, 'players'>` so the rest of the Sleeper roster shape passes through unchanged.
  - Type-predicate filter (`(p): p is PlayerCache => p != null`) drops any players missing from a stale cache, keeping the return type tight.
- **`server/src/routes/leagues.ts`** — `GET /` and `GET /rosters`, mounted at `/api/league` in `index.ts`. Express 5's async error handling means no try/catch ceremony.
- **`server/src/index.ts`** — mounts `leaguesRouter` at `/api/league`.

## Design notes

- Returns rosters with players **embedded** (denormalized) rather than a separate `players: Record<id, PlayerCache>` map — the roster page renders one team at a time, so embedded is simpler for the consumer.
- One `findMany` for all ~200 players across the league instead of 200 individual `findUnique`s.
- Helpers read env directly; route handlers don't pass IDs. Fine for a single-league local app.

## Test plan

- [x] `curl -s http://localhost:3000/api/league | jq` returns the league JSON ("GMs in Training")
- [x] `curl -s http://localhost:3000/api/league/rosters | jq 'map(.players | length)'` returns an array of ~30/roster
- [x] First player on roster 0 resolves to a real name (`Rashee Rice`, `WR`, `KC`, age 26)